### PR TITLE
Add more WASI conditional compilation

### DIFF
--- a/src/base/abc/abcShow.c
+++ b/src/base/abc/abcShow.c
@@ -363,7 +363,11 @@ void Abc_ShowFile( char * FileNameDot )
 
     // generate the PostScript file using DOT
     sprintf( CommandDot,  "%s -Tps -o %s %s", pDotName, FileNamePs, FileNameDot ); 
+#if defined(__wasm)
+    RetValue = -1;
+#else
     RetValue = system( CommandDot );
+#endif
     if ( RetValue == -1 )
     {
         fprintf( stdout, "Command \"%s\" did not succeed.\n", CommandDot );
@@ -401,7 +405,11 @@ void Abc_ShowFile( char * FileNameDot )
         char CommandPs[1000];
         unlink( FileNameDot );
         sprintf( CommandPs,  "%s %s &", pGsNameUnix, FileNamePs ); 
+#if defined(__wasm)
+        if ( 1 )
+#else
         if ( system( CommandPs ) == -1 )
+#endif
         {
             fprintf( stdout, "Cannot execute \"%s\".\n", CommandPs );
             return;

--- a/src/base/cmd/cmd.c
+++ b/src/base/cmd/cmd.c
@@ -2175,7 +2175,11 @@ void Gia_ManGnuplotShow( char * pPlotFileName )
     {
         char Command[1000];
         sprintf( Command, "%s %s ", pProgNameGnuplot, pPlotFileName );
+#if defined(__wasm)
+        if ( 1 )
+#else
         if ( system( Command ) == -1 )
+#endif
         {
             fprintf( stdout, "Cannot execute \"%s\".\n", Command );
             return;

--- a/src/base/cmd/cmdUtils.c
+++ b/src/base/cmd/cmdUtils.c
@@ -52,6 +52,9 @@ int cmdCheckShellEscape( Abc_Frame_t * pAbc, int argc, char ** argv)
     int RetValue;
     if (argv[0][0] == '!') 
     {
+#if defined(__wasm)
+        RetValue = -1;
+#else
         const int size = 4096;
         int i;
         char * buffer = ABC_ALLOC(char, 10000);
@@ -70,7 +73,7 @@ int cmdCheckShellEscape( Abc_Frame_t * pAbc, int argc, char ** argv)
         // the parts, we lose information. So a command like
         // `!ls "file name"` will be sent to the system as
         // `ls file name` which is a BUG
-
+#endif
         return 1;
     }
     else

--- a/src/base/main/mainReal.c
+++ b/src/base/main/mainReal.c
@@ -132,7 +132,7 @@ int Abc_RealMain( int argc, char * argv[] )
                 break;                                          
 
             case 'm': {
-#if !defined(WIN32) && !defined(ABC_NO_RLIMIT)
+#if !defined(WIN32) && !defined(__wasm)
                 int maxMb = atoi(globalUtilOptarg);             
                 printf("Limiting memory use to %d MB\n", maxMb);
                 struct rlimit limit = {                         
@@ -144,7 +144,7 @@ int Abc_RealMain( int argc, char * argv[] )
                 break; 
             }                                         
             case 'l': {
-#if !defined(WIN32) && !defined(ABC_NO_RLIMIT)
+#if !defined(WIN32) && !defined(__wasm)
                 rlim_t maxTime = atoi(globalUtilOptarg);           
                 printf("Limiting time to %d seconds\n", (int)maxTime);
                 struct rlimit limit = {                         

--- a/src/misc/util/utilFile.c
+++ b/src/misc/util/utilFile.c
@@ -102,6 +102,17 @@ int tmpFile(const char* prefix, const char* suffix, char** out_name)
     }
     assert(0);  // -- could not open temporary file
     return 0;
+#elif defined(__wasm)
+    static int seq = 0; // no risk of collision since we're in a sandbox
+    int fd;
+    *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 9);
+    sprintf(*out_name, "%s%08d%s", prefix, seq++, suffix);
+    fd = open(*out_name, O_CREAT | O_EXCL | O_RDWR, S_IREAD | S_IWRITE);
+    if (fd == -1){
+        free(*out_name);
+        *out_name = NULL;
+    }
+    return fd;
 #else
     int fd;
     *out_name = (char*)malloc(strlen(prefix) + strlen(suffix) + 7);

--- a/src/misc/util/utilSignal.c
+++ b/src/misc/util/utilSignal.c
@@ -43,7 +43,11 @@ ABC_NAMESPACE_IMPL_START
 
 int Util_SignalSystem(const char* cmd)
 {
+#if defined(__wasm)
+    return -1;
+#else
     return system(cmd);
+#endif
 }
 
 int tmpFile(const char* prefix, const char* suffix, char** out_name);


### PR DESCRIPTION
This is done so that Yosys doesn't have to define `mkstemp` and `system` internally, that being the last major hack in https://github.com/YosysHQ/yosys/pull/2001.