### PR TITLE
Add missing WASI platform support for signal.h

### DIFF
--- a/src/base/main/mainReal.c
+++ b/src/base/main/mainReal.c
@@ -49,7 +49,9 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #include <sys/times.h>   
 #include <sys/resource.h>
 #include <unistd.h>      
+#if !defined(__wasm)
 #include <signal.h>      
+#endif
 #include <stdlib.h>
 #endif
 

--- a/src/sat/glucose/IntTypes.h
+++ b/src/sat/glucose/IntTypes.h
@@ -28,20 +28,18 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #   include <sys/int_fmtio.h>
 #   include <sys/int_limits.h>
 
+#elif _WIN32
+
+#   include "pstdint.h"
+
 #else
 
-#define __STDC_LIMIT_MACROS
-#   include "pstdint.h"
-//#   include <inttypes.h>
+#   define __STDC_LIMIT_MACROS
+#   include <limits.h>
+#   include <inttypes.h>
 
 #endif
 
-#include <limits.h>
-
-#ifndef PRIu64
-#define PRIu64 "lu"
-#define PRIi64 "ld"
-#endif
 //=================================================================================================
 
 #include <misc/util/abc_namespaces.h>


### PR DESCRIPTION
This was accepted (erroneously I believe) in WASI SDK 10, but not in WASI SDK 11 anymore.