### PR TITLE
provide a fallback for systems without RLIMIT_AS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,11 @@ endif
 
 # LIBS := -ldl -lrt
 LIBS += -lm
-ifneq ($(OS), FreeBSD)
+ifneq ($(OS), $(filter $(OS), FreeBSD OpenBSD))
   LIBS += -ldl
 endif
 
-ifneq ($(findstring Darwin, $(shell uname)), Darwin)
+ifneq ($(OS), $(filter $(OS), FreeBSD OpenBSD Darwin))
    LIBS += -lrt
 endif
 


### PR DESCRIPTION
Related to https://github.com/YosysHQ/yosys/pull/3406, this permits to fix a missing `#define` on OpenBSD, as well as others.

```
$ gmake CC=cc CXX=c++
```

The error looks like this while compiling Yosys:

```
[100%] Building yosys-config
[100%] Building abc/abc-5f40c47
[ 95%] ABC: Using CC=clang
[ 95%] ABC: Using CXX=clang
[ 95%] ABC: Using AR=ar
[ 95%] ABC: Using LD=clang
[ 95%] ABC: Compiling in namespace
[ 95%] ABC: Compiling with CUDD
[ 95%] ABC: Using pthreads
[ 95%] ABC: Using explicit -lstdc++
[ 95%] ABC: Using CFLAGS=-Wall -Wno-unused-function -Wno-write-strings -Wno-sign-compare -DABC_USE_STDINT_H -Wno-c++11-narrowing -DABC_NAMESPACE=abc -fpermissive -x c++ -DABC_USE_CUDD=1 -DABC_USE_PTHREADS
[ 95%] ABC: `` Compiling: /src/base/main/mainReal.c
src/base/main/mainReal.c:144:27: error: use of undeclared identifier 'RLIMIT_AS'
                setrlimit(RLIMIT_AS, &limit);
                          ^
1 error generated.
gmake[1]: *** [Makefile:177: src/base/main/mainReal.o] Error 1
gmake: *** [Makefile:777: abc/abc-5f40c47] Error 2
```