### PR TITLE
casts: add casts for unsigned -> signed int

### DIFF
--- a/src/aig/gia/giaIso3.c
+++ b/src/aig/gia/giaIso3.c
@@ -177,7 +177,7 @@ Vec_Wec_t * Gia_Iso4Gia( Gia_Man_t * p )
     Vec_WecForEachLevel( vLevs, vLevel, l )
     {
         Gia_Obj_t * pObj;  int i;
-        int RandC[2] = { Abc_Random(0), Abc_Random(0) };
+        int RandC[2] = { (int)Abc_Random(0), (int)Abc_Random(0) };
         if ( l == 0 )
         {
             Gia_ManForEachObjVec( vLevel, p, pObj, i )

--- a/src/base/acb/acbTest.c
+++ b/src/base/acb/acbTest.c
@@ -421,8 +421,8 @@ Gia_Man_t * Acb_NtkGiaDeriveMiter( Gia_Man_t * pOne, Gia_Man_t * pTwo, int Type 
     {
         for ( i = 0; i < Gia_ManCoNum(pOne); i += 2 )
         {
-            int pLitsF[2] = { Gia_ManCo(pOne, i)->Value, Gia_ManCo(pOne, i+1)->Value };
-            int pLitsS[2] = { Gia_ManCo(pTwo, i)->Value, Gia_ManCo(pTwo, i+1)->Value };
+            int pLitsF[2] = { (int)Gia_ManCo(pOne, i)->Value, (int)Gia_ManCo(pOne, i+1)->Value };
+            int pLitsS[2] = { (int)Gia_ManCo(pTwo, i)->Value, (int)Gia_ManCo(pTwo, i+1)->Value };
             Gia_ManAppendCo( pNew, pLitsF[0] );
             Gia_ManAppendCo( pNew, pLitsS[0] );
         }
@@ -431,8 +431,8 @@ Gia_Man_t * Acb_NtkGiaDeriveMiter( Gia_Man_t * pOne, Gia_Man_t * pTwo, int Type 
     {
         for ( i = 0; i < Gia_ManCoNum(pOne); i += 2 )
         {
-            int pLitsF[2] = { Gia_ManCo(pOne, i)->Value, Gia_ManCo(pOne, i+1)->Value };
-            int pLitsS[2] = { Gia_ManCo(pTwo, i)->Value, Gia_ManCo(pTwo, i+1)->Value };
+            int pLitsF[2] = { (int)Gia_ManCo(pOne, i)->Value, (int)Gia_ManCo(pOne, i+1)->Value };
+            int pLitsS[2] = { (int)Gia_ManCo(pTwo, i)->Value, (int)Gia_ManCo(pTwo, i+1)->Value };
             Gia_ManAppendCo( pNew, pLitsF[1] );
             Gia_ManAppendCo( pNew, pLitsS[1] );
         }
@@ -441,8 +441,8 @@ Gia_Man_t * Acb_NtkGiaDeriveMiter( Gia_Man_t * pOne, Gia_Man_t * pTwo, int Type 
     {
         for ( i = 0; i < Gia_ManCoNum(pOne); i += 2 )
         {
-            int pLitsF[2] = { Gia_ManCo(pOne, i)->Value, Gia_ManCo(pOne, i+1)->Value };
-            int pLitsS[2] = { Gia_ManCo(pTwo, i)->Value, Gia_ManCo(pTwo, i+1)->Value };
+            int pLitsF[2] = { (int)Gia_ManCo(pOne, i)->Value, (int)Gia_ManCo(pOne, i+1)->Value };
+            int pLitsS[2] = { (int)Gia_ManCo(pTwo, i)->Value, (int)Gia_ManCo(pTwo, i+1)->Value };
             Gia_ManAppendCo( pNew, Gia_ManDualCompare( pNew, pLitsF, pLitsS ) );
         }
     }


### PR DESCRIPTION
When compiling on Darwin ARM64 hardware using the Conda clang compiler, compilation fails due to these casts going from `unsigned` to `int`.

In these cases, a cast appears to be the correct approach. Add a cast to make the compiler happy.