### PR TITLE
Fix C++ ODR violation in Glucose{,2}

### DIFF
--- a/src/sat/glucose/Glucose.cpp
+++ b/src/sat/glucose/Glucose.cpp
@@ -910,6 +910,7 @@ CRef Solver::propagate()
 |    Remove half of the learnt clauses, minus the clauses locked by the current assignment. Locked
 |    clauses are clauses that are reason to some assignment. Binary clauses are never removed.
 |________________________________________________________________________________________________@*/
+namespace {
 struct reduceDB_lt { 
     ClauseAllocator& ca;
     reduceDB_lt(ClauseAllocator& ca_) : ca(ca_) {}
@@ -931,6 +932,7 @@ struct reduceDB_lt {
     //return ca[x].size() > 2 && (ca[y].size() == 2 || ca[x].activity() < ca[y].activity()); } 
     }    
 };
+}
 
 void Solver::reduceDB()
 { 

--- a/src/sat/glucose2/Glucose2.cpp
+++ b/src/sat/glucose2/Glucose2.cpp
@@ -1070,6 +1070,7 @@ CRef Solver::propagate()
 |    Remove half of the learnt clauses, minus the clauses locked by the current assignment. Locked
 |    clauses are clauses that are reason to some assignment. Binary clauses are never removed.
 |________________________________________________________________________________________________@*/
+namespace {
 struct reduceDB_lt { 
     ClauseAllocator& ca;
     reduceDB_lt(ClauseAllocator& ca_) : ca(ca_) {}
@@ -1091,6 +1092,7 @@ struct reduceDB_lt {
     //return ca[x].size() > 2 && (ca[y].size() == 2 || ca[x].activity() < ca[y].activity()); } 
     }    
 };
+}
 
 void Solver::reduceDB()
 { 


### PR DESCRIPTION
The `reduceDB_lt` helper struct is defined in both Glucose and Glucose2, but both differ slightly, as recognized by e.g. GCC:

```
src/sat/glucose/Glucose.cpp:913:8: warning: type ‘struct reduceDB_lt’ violates the C++ One Definition Rule [-Wodr]
  913 | struct reduceDB_lt {
      |        ^
src/sat/glucose2/Glucose2.cpp:1073:8: note: a different type is defined in another translation unit
 1073 | struct reduceDB_lt {
      |        ^        
src/sat/glucose/Glucose.cpp:914:22: note: the first difference of corresponding definitions is field ‘ca’
  914 |     ClauseAllocator& ca;
      |                      ^        
src/sat/glucose2/Glucose2.cpp:1074:22: note: a field of same name but different type is defined in another translation unit
 1074 |     ClauseAllocator& ca;
      |                      ^        
./src/sat/glucose/SolverTypes.h:217:7: note: type name ‘Gluco::ClauseAllocator’ should match type name ‘Gluco2::ClauseAllocator’
  217 | class ClauseAllocator : public RegionAllocator<uint32_t>
      |       ^
./src/sat/glucose2/SolverTypes.h:223:7: note: the incompatible type is defined here
  223 | class ClauseAllocator : public RegionAllocator<uint32_t>
```

Put both into anonymous namespaces to make the scope of both definitions local to the translation unit.