### PR TITLE
Address some `&mfs` crashes

### DIFF
--- a/src/aig/gia/giaMfs.c
+++ b/src/aig/gia/giaMfs.c
@@ -517,6 +517,8 @@ Gia_Man_t * Gia_ManPerformMfs( Gia_Man_t * p, Sfm_Par_t * pPars )
     }
     // collect information
     pNtk = Gia_ManExtractMfs( p );
+    if (pPars->fTestReimport)
+        goto reimport;
     // perform optimization
     nNodes = Sfm_NtkPerform( pNtk, pPars );
     if ( nNodes == 0 )
@@ -529,6 +531,7 @@ Gia_Man_t * Gia_ManPerformMfs( Gia_Man_t * p, Sfm_Par_t * pPars )
     }
     else
     {
+    reimport:
         pNew = Gia_ManInsertMfs( p, pNtk, pPars->fAllBoxes );
         if( pPars->fVerbose )
             Abc_Print( 1, "The network has %d nodes changed by \"&mfs\".\n", nNodes );

--- a/src/aig/gia/giaMfs.c
+++ b/src/aig/gia/giaMfs.c
@@ -381,6 +381,15 @@ Gia_Man_t * Gia_ManInsertMfs( Gia_Man_t * p, Sfm_Ntk_t * pNtk, int fAllBoxes )
             continue;
         }
         Vec_IntClear( vLeaves );
+
+        // handle internal CIs first, before we go looking for vLeaves
+        if ( iGroup != -1 && Abc_LitIsCompl(iGroup) )
+        {
+            //Dau_DsdPrintFromTruth( pTruth, Vec_IntSize(vLeaves) );
+            iLitNew = Gia_ManAppendCi( pNew );
+            goto done;
+        }
+
         Vec_IntForEachEntry( vArray, Fanin, k )
         {
             iLitNew = Vec_IntEntry( vMfs2Gia, Fanin );  assert( iLitNew >= 0 );
@@ -405,17 +414,13 @@ Gia_Man_t * Gia_ManInsertMfs( Gia_Man_t * p, Sfm_Ntk_t * pNtk, int fAllBoxes )
             else
                 iLitNew = Gia_ManFromIfLogicCreateLut( pNew, pTruth, vLeaves, vCover, vMapping, vMapping2 );
         }
-        else if ( Abc_LitIsCompl(iGroup) ) // internal CI
-        {
-            //Dau_DsdPrintFromTruth( pTruth, Vec_IntSize(vLeaves) );
-            iLitNew = Gia_ManAppendCi( pNew );
-        }
         else // internal CO
         {
             assert( pTruth[0] == uTruthVar || pTruth[0] == ~uTruthVar );
             iLitNew = Gia_ManAppendCo( pNew, Abc_LitNotCond(Vec_IntEntry(vLeaves, 0), pTruth[0] == ~uTruthVar) );
             //printf("Group = %d. po = %d\n", iGroup>>1, iMfsId );
         }
+done:
         Vec_IntWriteEntry( vMfs2Gia, iMfsId, iLitNew );
     }
     Vec_IntFree( vCover );

--- a/src/base/abci/abc.c
+++ b/src/base/abci/abc.c
@@ -49096,7 +49096,7 @@ int Abc_CommandAbc9Mfs( Abc_Frame_t * pAbc, int argc, char ** argv )
     pPars->nDepthMax   =  100;
     pPars->nWinSizeMax = 2000;
     Extra_UtilGetoptReset();
-    while ( ( c = Extra_UtilGetopt( argc, argv, "WFDMLCNdaeblvwh" ) ) != EOF )
+    while ( ( c = Extra_UtilGetopt( argc, argv, "WFDMLCNdaeblvwhr" ) ) != EOF )
     {
         switch ( c )
         {
@@ -49192,6 +49192,9 @@ int Abc_CommandAbc9Mfs( Abc_Frame_t * pAbc, int argc, char ** argv )
         case 'l':
             pPars->fUseDcs ^= 1;
             break;
+        case 'r':
+            pPars->fTestReimport ^= 1;
+            break;
         case 'v':
             pPars->fVerbose ^= 1;
             break;
@@ -49261,6 +49264,7 @@ usage:
     Abc_Print( -2, "\t-l       : toggle deriving don't-cares [default = %s]\n",                                 pPars->fUseDcs? "yes": "no" );
     Abc_Print( -2, "\t-v       : toggle printing optimization summary [default = %s]\n",                        pPars->fVerbose? "yes": "no" );
     Abc_Print( -2, "\t-w       : toggle printing detailed stats for each node [default = %s]\n",                pPars->fVeryVerbose? "yes": "no" );
+    Abc_Print( -2, "\t-r       : toggle testing re-importing the network unchanged [default = %s]\n",           pPars->fTestReimport? "yes": "no" );
     Abc_Print( -2, "\t-h       : print the command usage\n");
     return 1;
 }

--- a/src/base/abci/abcMfs.c
+++ b/src/base/abci/abcMfs.c
@@ -216,7 +216,7 @@ Sfm_Ntk_t * Abc_NtkExtractMfs( Abc_Ntk_t * pNtk, int nFirstFixed )
 //    for ( i = Abc_NtkCiNum(pNtk); i + Abc_NtkCoNum(pNtk) < Abc_NtkObjNum(pNtk); i++ )
 //        if ( rand() % 10 == 0 )
 //            Vec_StrWriteEntry( vFixed, i, (char)1 );
-    return Sfm_NtkConstruct( vFanins, Abc_NtkCiNum(pNtk), Abc_NtkCoNum(pNtk), vFixed, NULL, vTruths, vStarts, vTruths2 );
+    return Sfm_NtkConstruct( vFanins, Abc_NtkCiNum(pNtk), Abc_NtkCoNum(pNtk), vFixed, NULL, NULL, vTruths, vStarts, vTruths2 );
 }
 Sfm_Ntk_t * Abc_NtkExtractMfs2( Abc_Ntk_t * pNtk, int iPivot )
 {
@@ -285,7 +285,7 @@ Sfm_Ntk_t * Abc_NtkExtractMfs2( Abc_Ntk_t * pNtk, int iPivot )
     Abc_NtkForEachNode( pNtk, pObj, i )
         if ( i >= iPivot )
             Vec_StrWriteEntry( vFixed, pObj->iTemp, (char)1 );
-    return Sfm_NtkConstruct( vFanins, Abc_NtkCiNum(pNtk), Abc_NtkCoNum(pNtk), vFixed, NULL, vTruths, vStarts, vTruths2 );
+    return Sfm_NtkConstruct( vFanins, Abc_NtkCiNum(pNtk), Abc_NtkCoNum(pNtk), vFixed, NULL, NULL, vTruths, vStarts, vTruths2 );
 }
 
 /**Function*************************************************************

--- a/src/opt/sfm/sfm.h
+++ b/src/opt/sfm/sfm.h
@@ -73,6 +73,7 @@ struct Sfm_Par_t_
     int             fDelayVerbose; // enable delay stats
     int             fVerbose;      // enable basic stats
     int             fVeryVerbose;  // enable detailed stats
+    int             fTestReimport; // enable testing of re-import
 };
 
 ////////////////////////////////////////////////////////////////////////

--- a/src/opt/sfm/sfm.h
+++ b/src/opt/sfm/sfm.h
@@ -89,7 +89,7 @@ struct Sfm_Par_t_
 extern void         Sfm_ParSetDefault( Sfm_Par_t * pPars );
 extern int          Sfm_NtkPerform( Sfm_Ntk_t * p, Sfm_Par_t * pPars );
 /*=== sfmNtk.c ==========================================================*/
-extern Sfm_Ntk_t *  Sfm_NtkConstruct( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t * vFixed, Vec_Str_t * vEmpty, Vec_Wrd_t * vTruths, Vec_Int_t * vStarts, Vec_Wrd_t * vTruths2 );
+extern Sfm_Ntk_t *  Sfm_NtkConstruct( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t * vFixed, Vec_Str_t * vEmpty, Vec_Str_t * vDenied, Vec_Wrd_t * vTruths, Vec_Int_t * vStarts, Vec_Wrd_t * vTruths2 );
 extern void         Sfm_NtkFree( Sfm_Ntk_t * p );
 extern Vec_Int_t *  Sfm_NodeReadFanins( Sfm_Ntk_t * p, int i );
 extern word *       Sfm_NodeReadTruth( Sfm_Ntk_t * p, int i );

--- a/src/opt/sfm/sfmCore.c
+++ b/src/opt/sfm/sfmCore.c
@@ -58,6 +58,7 @@ void Sfm_ParSetDefault( Sfm_Par_t * pPars )
     pPars->fAllBoxes    =    0;  // enable preserving all boxes
     pPars->fVerbose     =    0;  // enable basic stats
     pPars->fVeryVerbose =    0;  // enable detailed stats
+    pPars->fTestReimport =   0;  // enable testing of re-import
 }
 
 /**Function*************************************************************

--- a/src/opt/sfm/sfmInt.h
+++ b/src/opt/sfm/sfmInt.h
@@ -81,6 +81,7 @@ struct Sfm_Ntk_t_
     // user data
     Vec_Str_t *       vFixed;      // persistent objects
     Vec_Str_t *       vEmpty;      // transparent objects
+    Vec_Str_t *       vDenied;     // denied objects
     Vec_Wrd_t *       vTruths;     // truth tables
     Vec_Wec_t         vFanins;     // fanins
     Vec_Int_t *       vStarts;     // offsets
@@ -157,6 +158,7 @@ static inline int  Sfm_ObjIsPi( Sfm_Ntk_t * p, int i )                  { return
 static inline int  Sfm_ObjIsPo( Sfm_Ntk_t * p, int i )                  { return i + p->nPos >= p->nObjs;                   }
 static inline int  Sfm_ObjIsNode( Sfm_Ntk_t * p, int i )                { return i >= p->nPis && i + p->nPos < p->nObjs;    }
 static inline int  Sfm_ObjIsFixed( Sfm_Ntk_t * p, int i )               { return Vec_StrEntry(p->vFixed, i);                }
+static inline int  Sfm_ObjIsDenied( Sfm_Ntk_t * p, int i )              { return p->vDenied && Vec_StrEntry(p->vDenied, i); }
 static inline int  Sfm_ObjAddsLevelArray( Vec_Str_t * p, int i )        { return p == NULL || Vec_StrEntry(p, i) == 0;      }
 static inline int  Sfm_ObjAddsLevel( Sfm_Ntk_t * p, int i )             { return Sfm_ObjAddsLevelArray(p->vEmpty, i);       }
 

--- a/src/opt/sfm/sfmNtk.c
+++ b/src/opt/sfm/sfmNtk.c
@@ -58,7 +58,7 @@ void Sfm_CheckConsistency( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t * 
             assert( Fanin + nPos < Vec_WecSize(vFanins) );
         // POs have one fanout
         if ( i + nPos >= Vec_WecSize(vFanins) )
-            assert( Vec_IntSize(vArray) == 1 && Vec_StrEntry(vFixed, i) == (char)0 );
+            assert( Vec_IntSize(vArray) == 1 );
     }
 }
 
@@ -164,7 +164,7 @@ void Sfm_CreateLevelR( Vec_Wec_t * vFanouts, Vec_Int_t * vLevelsR, Vec_Str_t * v
   SeeAlso     []
 
 ***********************************************************************/
-Sfm_Ntk_t * Sfm_NtkConstruct( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t * vFixed, Vec_Str_t * vEmpty, Vec_Wrd_t * vTruths, Vec_Int_t * vStarts, Vec_Wrd_t * vTruths2 )
+Sfm_Ntk_t * Sfm_NtkConstruct( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t * vFixed, Vec_Str_t * vEmpty, Vec_Str_t * vDenied, Vec_Wrd_t * vTruths, Vec_Int_t * vStarts, Vec_Wrd_t * vTruths2 )
 {
     Sfm_Ntk_t * p; int i;
     Sfm_CheckConsistency( vFanins, nPis, nPos, vFixed );
@@ -177,6 +177,7 @@ Sfm_Ntk_t * Sfm_NtkConstruct( Vec_Wec_t * vFanins, int nPis, int nPos, Vec_Str_t
     p->vFixed   = vFixed;
     p->vEmpty   = vEmpty;
     p->vTruths  = vTruths;
+    p->vDenied  = vDenied;
     p->vFanins  = *vFanins;
     p->vStarts  = vStarts;
     p->vTruths2 = vTruths2;
@@ -221,6 +222,7 @@ void Sfm_NtkFree( Sfm_Ntk_t * p )
     // user data
     Vec_StrFree( p->vFixed );
     Vec_StrFreeP( &p->vEmpty );
+    Vec_StrFreeP( &p->vDenied );
     Vec_WrdFree( p->vTruths );
     Vec_WecErase( &p->vFanins );
     Vec_IntFree( p->vStarts );


### PR DESCRIPTION
Yosys calls `&mfs` as part of the default abc9 flow but every time it does it's prepared for the worst, and is ready to recover when the command crashes (see YosysHQ/yosys#1974). In this PR we try to make it crash less, see the individual commits for details.