### PR TITLE
Fix Assertion using &if: `pCutSet->nCuts > 0'

### DIFF
--- a/src/map/if/ifMap.c
+++ b/src/map/if/ifMap.c
@@ -444,7 +444,7 @@ void If_ObjPerformMappingAnd( If_Man_t * p, If_Obj_t * pObj, int Mode, int fPrep
             pCut->Delay = If_CutDelay( p, pObj, pCut );
         if ( pCut->Delay == -1 )
             continue;
-        if ( Mode && pCut->Delay > pObj->Required + p->fEpsilon )
+        if ( Mode && pCut->Delay > pObj->Required + p->fEpsilon && pCutSet->nCuts > 0 )
             continue;
         // compute area of the cut (this area may depend on the application specific cost)
         pCut->Area = (Mode == 2)? If_CutAreaDerefed( p, pCut ) : If_CutAreaFlow( p, pCut );

--- a/src/map/if/ifMap.c
+++ b/src/map/if/ifMap.c
@@ -542,7 +542,7 @@ void If_ObjPerformMappingChoice( If_Man_t * p, If_Obj_t * pObj, int Mode, int fP
                 continue;
             // check if the cut satisfies the required times
 //            assert( pCut->Delay == If_CutDelay( p, pTemp, pCut ) );
-            if ( Mode && pCut->Delay > pObj->Required + p->fEpsilon )
+            if ( Mode && pCut->Delay > pObj->Required + p->fEpsilon && pCutSet->nCuts > 0 )
                 continue;
             // set the phase attribute
             pCut->fCompl = pObj->fPhase ^ pTemp->fPhase;


### PR DESCRIPTION
This is a fix/workaround for the crash described in https://github.com/berkeley-abc/abc/issues/55 and https://github.com/berkeley-abc/abc/issues/165, using the patch suggested by @gatecat in https://github.com/berkeley-abc/abc/issues/55#issuecomment-546612665. As described by @alanminko in that issue:

> The fix is basically saying: when the mapper is in delay-mode (Mode==1) and delay of the output of the cut exceeds its required times, we will accept it - if there is no other cuts.  Indeed, this will prevent the situation when no cuts meet the required times (as in this case), but in general it can lead to an increase in the delay of the mapping...   Please feel free to use the fix until I have time to look into it

Given that yosys has triggered this bug for multiple people over the years, it seems it would be good to use this workaround for now rather than continuing to wait for an improved fix?