### PR TITLE
CMake: use stdint.h if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ if( APPLE )
     set(make_env ${CMAKE_COMMAND} -E env SDKROOT=${CMAKE_OSX_SYSROOT})
 endif()
 
+include(CheckIncludeFile)
+check_include_file(stdint.h HAS_STDINT)
+if(${HAS_STDINT})
+    list(APPEND ABC_STDINT_FLAGS "ABC_USE_STDINT_H=1")
+endif()
+
 # run make to extract compiler options, linker options and list of source files
 execute_process(
   COMMAND
@@ -58,6 +64,7 @@ execute_process(
     make
         ${ABC_READLINE_FLAGS}
         ${ABC_USE_NAMESPACE_FLAGS}
+        ${ABC_STDINT_FLAGS}
         ARCHFLAGS_EXE=${CMAKE_CURRENT_BINARY_DIR}/abc_arch_flags_program.exe
         ABC_MAKE_NO_DEPS=1
         CC=${CMAKE_C_COMPILER}


### PR DESCRIPTION
yosys [builds abc with stdint.h](https://github.com/YosysHQ/yosys/blob/75f01ccee82684e2bdbbb5e0d4b8ec247c5e1533/Makefile#L211) depending on the config for legacy reasons. For Yosys to be comfortably, equivalently built with nix, with abc as an external package ([ABCEXTERNAL](https://github.com/YosysHQ/yosys/blob/75f01ccee82684e2bdbbb5e0d4b8ec247c5e1533/Makefile#L164)), it is easier to use the current `abc-verifier` [package in nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-23.11/pkgs/applications/science/logic/abc/default.nix#L32), which uses CMake. 

Therefore, we should let stdint.h be used in abc whenever CMake knows it's available. That's what this PR does.