### PR TITLE
Fix archive reproducibility

### DIFF
--- a/.gitcommit
+++ b/.gitcommit
@@ -1,1 +1,1 @@
-$Format:%h$
+$Format:%H$


### PR DESCRIPTION
The git archive export-subst option does not have consistent results over time, since the abbreviated commit hash can get longer over time.

Instead, let's export the full commit hash.

This was found in an audit of source archive reproducibility in nixpkgs:

```
~ » expected=$(nix-store -r /nix/store/4j9rj4m6akjskp0f7k923qff817k6hv5-source)
actual=$(nix-prefetch-url --print-path --unpack --name source https://github.com/yosyshq/abc/archive/896e5e7dedf9b9b1459fa019f1fa8aa8101fdf43.tar.gz | tail -n1)
nix-shell -p diffoscope --run "diffoscope $expected $actual"
this path will be fetched (3.77 MiB download, 34.50 MiB unpacked):
  /nix/store/4j9rj4m6akjskp0f7k923qff817k6hv5-source
copying path '/nix/store/4j9rj4m6akjskp0f7k923qff817k6hv5-source' from 'https://cache.nixos.org'...
warning: you did not specify '--add-root'; the result might be removed by the garbage collector
--- /nix/store/4j9rj4m6akjskp0f7k923qff817k6hv5-source
+++ /nix/store/v7ms5ghibzi8pk71nzlhvsbn7a0rdpy7-source
│   --- /nix/store/4j9rj4m6akjskp0f7k923qff817k6hv5-source/.gitcommit
├── +++ /nix/store/v7ms5ghibzi8pk71nzlhvsbn7a0rdpy7-source/.gitcommit
│ @@ -1 +1 @@
│ -896e5e7de
│ +896e5e7ded
│ ├── stat {}
│ │ @@ -1,7 +1,7 @@
│ │
│ │ -  Size: 10        	Blocks: 1          IO Block: 512    regular file
│ │ +  Size: 11        	Blocks: 1          IO Block: 512    regular file
│ │  Device: 0,24	Access: (0444/-r--r--r--)  Uid: (    0/    root)   Gid: (    0/    root)
│ │
│ │  Modify: 1970-01-01 00:00:01.000000000 +0000
```